### PR TITLE
Bump packages versions (fix PHP 7.4 issue #27)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "league/plates": "^3.3",
-        "erusev/parsedown-extra": "^0.7",
-        "symfony/yaml": "^4.0",
+        "erusev/parsedown-extra": "^0.8",
+        "symfony/yaml": "^4.0 || ^5.0",
         "pimple/pimple": "^3.2",
         "slim/slim": "^3.8",
         "tuupola/slim-jwt-auth": "^2.4",
         "php-jsonpatch/php-jsonpatch": "^3.0",
-        "wikimedia/composer-merge-plugin": "^1.4",
+        "wikimedia/composer-merge-plugin": "^1.4 || ^2.0",
         "psr/container": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Bump some dependencies, it should fix potential issues with PHP 7.4 (https://github.com/erusev/parsedown-extra/issues/140)